### PR TITLE
fix: main file not compiled on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "jest",
-    "prepare": "tsc"
+    "postinstall": "tsc"
   },
   "files": [
     "dist"


### PR DESCRIPTION
`prepare` command exists on npm publish only, not on npm install